### PR TITLE
New Feature: Post to Twitter

### DIFF
--- a/app/controllers/short_links_controller.rb
+++ b/app/controllers/short_links_controller.rb
@@ -1,11 +1,6 @@
 class ShortLinksController < ApplicationController
-  def discussion
+  def post
     # TODO: add logging for analytics
-    redirect_to discussion_url(params[:id]), status: :moved_permanently
-  end
-
-  def tutorial
-    # TODO: add logging for analytics
-    redirect_to tutorial_url(params[:id]), status: :moved_permanently
+    redirect_to post_url(params[:id], host: 'rubygamedev.com'), status: :moved_permanently
   end
 end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -2,18 +2,4 @@ class Discussion < ActiveRecord::Base
   belongs_to :user
   has_many :comments, as: :parent
   validates_presence_of :title, :body, :user
-  after_create :notify_twitter
-
-  # TODO: move this to background job
-  def notify_twitter
-    $twitter_client.update(tweet_content)
-  end
-
-  def tweet_content
-    intro = 'New Discussion: '
-    url = Rails.application.routes.url_helpers.discussion_short_link_url(self, host: 'rbga.me')
-    url = " #{url}"
-    max_title_length = 140 - intro.length - url.length
-    intro + title[0...max_title_length] + url
-  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -9,4 +9,17 @@ class Post < ActiveRecord::Base
     parser = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true)
     self.body_html = parser.render(body_markdown)
   end
+
+  after_create :notify_twitter
+  # TODO: move this to background job
+  def notify_twitter
+    $twitter_client.update(tweet_content)
+  end
+
+  def tweet_content
+    url = Rails.application.routes.url_helpers.post_short_link_url(self, host: 'rbga.me')
+    url = " #{url}"
+    max_title_length = 140 - url.length
+    title[0...max_title_length] + url
+  end
 end

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,23 +1,9 @@
 class Tutorial < ActiveRecord::Base
   belongs_to :user
   validates_presence_of :user, :title
-  after_create :notify_twitter
 
   # TODO: implement voting
   def score
     0
-  end
-
-  # TODO: move this to background job
-  def notify_twitter
-    $twitter_client.update(tweet_content)
-  end
-
-  def tweet_content
-    intro = 'New Tutorial: '
-    url = Rails.application.routes.url_helpers.tutorial_short_link_url(self, host: 'rbga.me')
-    url = " #{url}"
-    max_title_length = 140 - intro.length - url.length
-    intro + title[0...max_title_length] + url
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,15 +17,12 @@ Rubygamedev::Application.routes.draw do
   resources :libraries
   resources :library_categories
 
-  # namespace :blog do
-  #   root 'posts#index'
-  #   resources :posts
-  # end
-
-  get 'd/:id' => 'short_links#discussion', as: :discussion_short_link
-  get 't/:id' => 'short_links#tutorial', as: :tutorial_short_link
-  
   get 'about' => 'pages#about', as: :about_page
   root 'pages#home'
+
+  # Short Links
+  get 'd/:id' => 'short_links#post' # DEPRECATED
+  get 't/:id' => 'short_links#post' # DEPRECATED
+  get ':id' => 'short_links#post', as: :post_short_link, constraints: { id: /\d+/ }
 
 end

--- a/spec/controllers/short_links_controller_spec.rb
+++ b/spec/controllers/short_links_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe ShortLinksController do
+
+  describe 'GET #post' do
+    it 'redirects to the full post URL' do
+      get :post, id: '123abc'
+      response.should redirect_to post_url(host: 'rubygamedev.com')
+    end
+  end
+
+end

--- a/spec/factories/post.rb
+++ b/spec/factories/post.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :post do
+    user
+    title 'Example Discussion'
+    body_markdown 'Example body. So **strong**.'
+  end
+end

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -5,39 +5,4 @@ describe Discussion do
   it { should validate_presence_of :title }
   it { should validate_presence_of :body }
   it { should validate_presence_of :user }
-
-  describe '#notify_twitter' do
-    subject { FactoryGirl.build(:discussion) }
-
-    it 'posts to Twitter after create' do
-      expect(subject).to receive(:notify_twitter)
-      subject.save!
-    end
-  end
-
-  describe '#tweet_content' do
-    subject { FactoryGirl.build(:discussion) }
-
-    it 'includes the title in the tweet' do
-      subject.id = '123'
-      subject.title = 'This is a test discussion'
-      subject.tweet_content.should match /^New Discussion: This is a test discussion/
-    end
-
-    it 'uses the short domain for links' do
-      subject.id = '123'
-      subject.tweet_content.should match %r{http://rbga.me/d/123$}
-    end
-
-    it 'keeps the character limit to 140' do
-      subject.id = '123'
-      subject.title = 'a' * 140
-      subject.tweet_content.length.should == 140
-      subject.tweet_content.should == "New Discussion: #{'a'*103} http://rbga.me/d/123"
-
-      subject.id = '1234567890'
-      subject.tweet_content.length.should == 140
-      subject.tweet_content.should == "New Discussion: #{'a'*96} http://rbga.me/d/1234567890"
-    end
-  end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -12,4 +12,39 @@ describe Post do
 
   it { should validate_presence_of :user }
   it { should validate_presence_of :title }
+
+  describe '#notify_twitter' do
+    subject { FactoryGirl.build(:post) }
+
+    it 'posts to Twitter after create' do
+      expect(subject).to receive(:notify_twitter)
+      subject.save!
+    end
+  end
+
+  describe '#tweet_content' do
+    subject { FactoryGirl.build(:post) }
+
+    it 'includes the title in the tweet' do
+      subject.id = '123'
+      subject.title = 'This is a test discussion'
+      subject.tweet_content.should match /^This is a test discussion/
+    end
+
+    it 'uses the short domain for links' do
+      subject.id = '123'
+      subject.tweet_content.should match %r{http://rbga.me/123$}
+    end
+
+    it 'keeps the character limit to 140' do
+      subject.id = '123'
+      subject.title = 'a' * 140
+      subject.tweet_content.length.should == 140
+      subject.tweet_content.should == "#{'a'*121} http://rbga.me/123"
+
+      subject.id = '1234567890'
+      subject.tweet_content.length.should == 140
+      subject.tweet_content.should == "#{'a'*114} http://rbga.me/1234567890"
+    end
+  end
 end

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -4,39 +4,4 @@ describe Tutorial do
   it { should belong_to :user }
   it { should validate_presence_of :title }
   it { should validate_presence_of :user }
-
-  describe '#notify_twitter' do
-    subject { FactoryGirl.build(:tutorial) }
-
-    it 'posts to Twitter after create' do
-      expect(subject).to receive(:notify_twitter)
-      subject.save!
-    end
-  end
-
-  describe '#tweet_content' do
-    subject { FactoryGirl.build(:tutorial) }
-
-    it 'includes the title in the tweet' do
-      subject.id = '123'
-      subject.title = 'This is a test tutorial'
-      subject.tweet_content.should match /^New Tutorial: This is a test tutorial/
-    end
-
-    it 'uses the short domain for links' do
-      subject.id = '123'
-      subject.tweet_content.should match %r{http://rbga.me/t/123$}
-    end
-
-    it 'keeps the character limit to 140' do
-      subject.id = '123'
-      subject.title = 'a' * 140
-      subject.tweet_content.length.should == 140
-      subject.tweet_content.should == "New Tutorial: #{'a'*105} http://rbga.me/t/123"
-
-      subject.id = '1234567890'
-      subject.tweet_content.length.should == 140
-      subject.tweet_content.should == "New Tutorial: #{'a'*98} http://rbga.me/t/1234567890"
-    end
-  end
 end

--- a/spec/routing/short_link_routes_spec.rb
+++ b/spec/routing/short_link_routes_spec.rb
@@ -2,12 +2,22 @@ require 'spec_helper'
 
 describe 'Short Link Routes' do
 
-  it 'routes discussion links' do
-    { get: 'd/1' }.should route_to(controller: 'short_links', action: 'discussion', id: '1')
+  context 'DEPRECATED' do
+    it 'routes discussion links' do
+      { get: 'd/1' }.should route_to(controller: 'short_links', action: 'post', id: '1')
+    end
+
+    it 'routes tutorial links' do
+      { get: 't/1' }.should route_to(controller: 'short_links', action: 'post', id: '1')
+    end
   end
 
-  it 'routes tutorial links' do
-    { get: 't/1' }.should route_to(controller: 'short_links', action: 'tutorial', id: '1')
+  it 'routes post links' do
+    { get: '1' }.should route_to(controller: 'short_links', action: 'post', id: '1')
+  end
+
+  it 'only routes numeric IDs' do
+    { get: '123abc' }.should_not route_to(controller: 'short_links', action: 'post', id: 'abc123')
   end
 
   context 'when route is not found' do


### PR DESCRIPTION
## New Features:
- Creating a new Post now automatically posts to the @rubygamedev Twitter account. (This feature existed before the migration to a generic Post model, but I forgot to copy that over).
- Clicking on the short link in a tweet now redirects to the full URL instead of staying on the short rbga.me domain. Fixes #25
