### PR TITLE
Add ability to create a new account or sign in using email/password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 
 # ignore private provisioning recipes (for now)
 /config/sunzi
+
+# ignore private SSL certificate info
+/ssl

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
 - 2.1.2
+sudo: false
 deploy:
   provider: ninefold
   app_id: '8650'

--- a/Gemfile
+++ b/Gemfile
@@ -17,10 +17,12 @@ gem 'jquery-rails'
 gem 'turbolinks'
 # TODO: upgrade to latest bootstrap
 gem 'bootstrap-sass', github: 'thomas-mcdonald/bootstrap-sass'
+gem 'quiet_assets', group: :development
 
 # authentication
 gem 'omniauth'
 gem 'omniauth-github'
+gem 'clearance'
 
 # social
 gem 'twitter' # used for posting updates
@@ -33,8 +35,8 @@ gem 'dotenv-rails' # for managing environment variables
 gem 'whenever', :require => false # for managing crontab
 
 # deployment and provisioning
-gem 'sunzi'
-gem 'capistrano', '~> 2.15'
+# gem 'sunzi'
+# gem 'capistrano', '~> 2.15'
 
 # monitoring/reporting
 gem 'newrelic_rpm'
@@ -58,7 +60,7 @@ end
 gem 'jbuilder', '~> 1.2'
 
 group :development, :test do
-  gem 'pry'
+  gem 'pry-remote'
   gem 'guard'
   gem 'guard-rspec'
   gem 'terminal-notifier-guard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,20 +35,19 @@ GEM
     addressable (2.3.5)
     arel (4.0.0)
     atomic (1.1.14)
+    bcrypt (3.1.7)
     buftok (0.2.0)
     bugsnag (1.8.0)
       httparty (>= 0.6, < 1.0)
       multi_json (~> 1.0)
     builder (3.1.4)
-    capistrano (2.15.5)
-      highline
-      net-scp (>= 1.0.0)
-      net-sftp (>= 2.0.0)
-      net-ssh (>= 2.0.14)
-      net-ssh-gateway (>= 1.1.0)
     celluloid (0.15.2)
       timers (~> 1.1.0)
     chronic (0.10.2)
+    clearance (1.4.2)
+      bcrypt
+      email_validator (~> 1.4)
+      rails (>= 3.1)
     coderay (1.0.9)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -64,6 +63,8 @@ GEM
     dotenv (0.9.0)
     dotenv-rails (0.9.0)
       dotenv (= 0.9.0)
+    email_validator (1.4.0)
+      activemodel
     equalizer (0.0.9)
     erubis (2.7.0)
     execjs (2.0.2)
@@ -85,7 +86,6 @@ GEM
     guard-rspec (1.2.1)
       guard (>= 1.1)
     hashie (2.0.5)
-    highline (1.6.20)
     hike (1.2.3)
     http (0.5.0)
       http_parser.rb
@@ -122,13 +122,6 @@ GEM
     multi_json (1.8.2)
     multi_xml (0.5.5)
     multipart-post (1.2.0)
-    net-scp (1.1.2)
-      net-ssh (>= 2.6.5)
-    net-sftp (2.1.2)
-      net-ssh (>= 2.6.5)
-    net-ssh (2.7.0)
-    net-ssh-gateway (1.2.0)
-      net-ssh (>= 2.6.5)
     newrelic_rpm (3.6.9.171)
     oauth2 (0.8.1)
       faraday (~> 0.8)
@@ -151,8 +144,13 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
+    pry-remote (0.1.8)
+      pry (~> 0.9)
+      slop (~> 3.0)
     pundit (0.2.1)
       activesupport (>= 3.0.0)
+    quiet_assets (1.0.3)
+      railties (>= 3.1, < 5.0)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -169,7 +167,6 @@ GEM
       activesupport (= 4.0.0)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (1.1.4)
     raindrops (0.12.0)
     rake (10.1.0)
     rb-fsevent (0.9.4)
@@ -218,10 +215,6 @@ GEM
       activesupport (>= 3.0)
       sprockets (~> 2.8)
     sqlite3 (1.3.8)
-    sunzi (1.3.0)
-      net-ssh
-      rainbow
-      thor
     terminal-notifier-guard (1.5.3)
     therubyracer (0.12.0)
       libv8 (~> 3.16.14.0)
@@ -268,7 +261,7 @@ PLATFORMS
 DEPENDENCIES
   bootstrap-sass!
   bugsnag
-  capistrano (~> 2.15)
+  clearance
   coffee-rails (~> 4.0.0)
   dotenv-rails
   factory_girl_rails (~> 4.4.0)
@@ -280,15 +273,15 @@ DEPENDENCIES
   omniauth
   omniauth-github
   pg
-  pry
+  pry-remote
   pundit
+  quiet_assets
   rails (~> 4.0.0)
   redcarpet
   rspec-rails (= 3.0.0.beta1)
   sass-rails (~> 4.0.0)
   shoulda
   sqlite3
-  sunzi
   terminal-notifier-guard
   therubyracer
   turbolinks

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,29 +1,12 @@
 class ApplicationController < ActionController::Base
+  include Clearance::Controller
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-  
+
   include Pundit # for authorization
-  # after_filter :verify_authorized, :except => :index # TODO: enable this once most areas have started using this
-  
-  helper_method :current_user
-  helper_method :signed_in?
 
-  def signed_in?
-    session[:user_id].present?
-  end
-
-  def current_user
-    @current_user ||= (User.find(session[:user_id]) if session[:user_id]) || User.new
-  end
-
-  def require_authentication
-    if signed_in?
-      true
-    else
-      redirect_to sign_in_path, notice: 'You must be signed in to perform that action.'
-      false
-    end
-  end
+  # TODO: enable this once most areas have started using pundit for authorization
+  # after_filter :verify_authorized, :except => :index
 
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,6 @@
 class CommentsController < ApplicationController
   before_action :set_comment, only: [:show, :edit, :update, :destroy]
-  before_action :require_authentication, except: [:index, :show]
+  before_action :authorize, except: [:index, :show]
 
   # GET /comments
   # GET /comments.json

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -1,6 +1,6 @@
 class DiscussionsController < ApplicationController
   before_action :set_discussion, only: [:show, :edit, :update, :destroy]
-  before_action :require_authentication, except: [:index, :show]
+  before_action :authorize, except: [:index, :show]
 
   # GET /discussions
   # GET /discussions.json

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :set_post, only: [:show, :edit, :update, :destroy]
-  before_action :require_authentication, except: [:index, :show]
+  before_action :authorize, except: [:index, :show]
 
   # GET /posts
   # GET /posts.json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,16 +1,25 @@
-class UsersController < ApplicationController
+class UsersController < Clearance::UsersController
 
   # all actions in this controller are scoped to the current_user
+  before_action :validate_editor, only: [:edit, :update]
 
-  before_filter :validate_editor, only: [:edit, :update]
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      sign_in @user
+      redirect_back_or url_after_create
+    else
+      render template: 'users/new'
+    end
+  end
 
-  def edit
+  def edit_current_user
   end
 
   def update
     respond_to do |format|
       if current_user.update(user_params)
-        format.html { redirect_to params[:redirect_to] || edit_user_path(current_user), notice: 'Your information was successfully saved.' }
+        format.html { redirect_to params[:redirect_to] || account_path, notice: 'Your information was successfully saved.' }
         format.json { head :no_content }
       else
         format.html { render action: 'edit' }
@@ -28,6 +37,6 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:username, :email, :dismissed_welcome_message, :digest_subscriber, :digest_frequency)
+    params.require(:user).permit(:username, :email, :password, :dismissed_welcome_message, :digest_subscriber, :digest_frequency)
   end
 end

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,0 +1,22 @@
+class Authentication < ActiveRecord::Base
+
+  belongs_to :user
+
+  def self.find_or_create_from_auth_hash(auth_hash)
+    find_by_provider_and_uid(auth_hash['provider'], auth_hash['uid']) || create_from_auth_hash(auth_hash)
+  end
+
+  def self.create_from_auth_hash(auth_hash)
+    create! do |auth|
+      auth.provider = auth_hash['provider']
+      auth.uid = auth_hash['uid']
+      auth.token = auth_hash['credentials']['token']
+    end
+  end
+
+  def update_token(auth_hash)
+    self.token = auth_hash['credentials']['token']
+    save
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,14 +1,24 @@
 class User < ActiveRecord::Base
+  include Clearance::User
+  has_many :authentications, dependent: :destroy
 
   has_many :tutorials
   has_many :discussions
 
-  def self.create_from_auth_hash(auth_hash)
-    create(github_id: auth_hash['uid'], username: auth_hash['info']['nickname'], email: auth_hash['info']['email'])
+  validates_presence_of :username # for display name
+  validates_uniqueness_of :email
+
+  def self.create_with_auth_and_hash(authentication, auth_hash)
+    create! do |u|
+      u.username = auth_hash['info']['name']
+      u.email = auth_hash['info']['email']
+      u.password = SecureRandom.hex(24) # generate a 24 character random password
+      u.authentications << authentication
+    end
   end
 
   def admin?
-    id == 1
+    id == 1 # Andrew Havens
   end
 
 end

--- a/app/views/clearance_mailer/change_password.html.erb
+++ b/app/views/clearance_mailer/change_password.html.erb
@@ -1,0 +1,5 @@
+<%= t('.opening') %>
+
+<%= edit_user_password_url(@user, :token => @user.confirmation_token.html_safe) %>
+
+<%= t('.closing') %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
     <%= yield :breadcrumbs %>
     <%= yield %>
   </div>
-  
+
   <div class="col-md-3">
     <%= yield :sidebar %>
   </div>

--- a/app/views/layouts/one_column.html.erb
+++ b/app/views/layouts/one_column.html.erb
@@ -47,14 +47,16 @@
             <% if signed_in? %>
               <li></li>
               <li class="dropdown">
-                <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= "Welcome, #{current_user.username}!" %> <b class="caret"></b></a>
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= current_user.email %> <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><%= link_to "Edit Profile", edit_user_path(current_user) %></li>
-                  <li><%= link_to 'Sign Out', '/auth/sign_out' %></li>
+                  <li><%= link_to "Edit Profile", account_path %></li>
+                  <li><%= link_to 'Sign Out', sign_out_path, method: :delete %></li>
                 </ul>
               </li>
             <% else %>
-              <li><%= link_to '<i class="fa fa-lg fa-github"></i> Sign in through GitHub'.html_safe, '/auth/github' %></li>
+              <li><%= link_to 'Create Account', sign_up_path %></li>
+              <li><%= link_to 'Sign in', sign_in_path %></li>
+              <!--<li><%= link_to '<i class="fa fa-lg fa-github"></i> Sign in through GitHub'.html_safe, '/auth/github' %></li>-->
             <% end %>
           </ul>
         </div>
@@ -63,7 +65,7 @@
 
     <div class="container">
       <% flash.each do |name, msg| -%>
-        <div id="welcome_message" class="alert alert-info alert-dismissable">
+        <div class="alert alert-info alert-dismissable">
           <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
           <%= msg %>
         </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,4 +1,4 @@
-<% unless signed_in? and current_user.dismissed_welcome_message %>
+<% if signed_in? and !current_user.dismissed_welcome_message %>
   <div id="welcome_message" class="alert alert-success alert-dismissable">
     <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
     Welcome to RubyGameDev.com, the community-driven, information hub which helps others to build games in Ruby! First time here? <%= link_to 'Learn More', about_page_path, class: 'alert-link' %>.
@@ -18,7 +18,7 @@
         <%= render 'posts/list' %>
       </div>
     </div>
- 
+
 <!-- TODO: build out the libraries section
     <div class="panel panel-default">
       <div class="panel-body">
@@ -27,7 +27,7 @@
         <%= render 'library_categories/table' %>
       </div>
     </div> -->
-    
+
   </div>
 
   <div class="col-md-5">

--- a/app/views/passwords/create.html.erb
+++ b/app/views/passwords/create.html.erb
@@ -1,0 +1,3 @@
+<div id="clearance" class="password-reset">
+  <p><%= t '.description' %></p>
+</div>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,0 +1,18 @@
+<div id="clearance" class="password-reset">
+  <h2><%= t '.title' %></h2>
+
+  <p><%= t '.description' %></p>
+
+  <%= form_for :password_reset,
+        :url => user_password_path(@user, :token => @user.confirmation_token),
+        :html => { :method => :put } do |form| %>
+    <div class="password-field">
+      <%= form.label :password %>
+      <%= form.password_field :password %>
+    </div>
+
+    <div class="submit-field">
+      <%= form.submit %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,0 +1,16 @@
+<div id="clearance" class="password-reset">
+  <h2><%= t '.title' %></h2>
+
+  <p><%= t '.description' %></p>
+
+  <%= form_for :password, :url => passwords_path do |form| %>
+    <div class="text-field">
+      <%= form.label :email %>
+      <%= form.text_field :email, :type => 'email' %>
+    </div>
+
+    <div class="submit-field">
+      <%= form.submit %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -1,0 +1,23 @@
+<%= form_for :session, :url => session_path, class: 'form-horizontal' do |form| %>
+
+  <fieldset>
+    <div class="form-group">
+      <%= form.label :email, class: 'col-sm-3 control-label' %>
+      <div class="col-sm-9">
+        <%= form.email_field :email, class: 'form-control' %>
+      </div>
+    </div>
+    <div class="form-group">
+      <%= form.label :password, class: 'col-sm-3 control-label' %>
+      <div class="col-sm-9">
+        <%= form.password_field :password, class: 'form-control' %>
+      </div>
+    </div>
+  </fieldset>
+
+  <div class="form-actions col-sm-offset-3 col-sm-9">
+    <%= form.submit class: 'btn btn-primary' %>
+    <%= link_to t('.forgot_password'), new_password_path %>
+  </div>
+
+<% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,2 +1,15 @@
-<h1>Sign In</h1>
-<p><%= link_to '<i class="fa fa-lg fa-github"></i> Sign in through GitHub'.html_safe, '/auth/github' %></p>
+<header>
+  <h1><%= t '.title' %></h1>
+</header>
+
+<div class="row">
+  <div class="col-md-6 col-sm-8 col-xs-8">
+    <%= render :partial => '/sessions/form' %>
+  </div>
+
+  <div class="col-md-6 col-sm-6 col-xs-6">
+    <div class="no_account">
+      <p><%= link_to '<i class="fa fa-lg fa-github"></i> Sign in through GitHub'.html_safe, '/auth/github', class: 'btn btn-default btn-lg' %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/sessions/old_new.html.erb
+++ b/app/views/sessions/old_new.html.erb
@@ -1,0 +1,2 @@
+<h1>Sign In</h1>
+<p><%= link_to '<i class="fa fa-lg fa-github"></i> Sign in through GitHub'.html_safe, '/auth/github' %></p>

--- a/app/views/users/edit_current_user.html.erb
+++ b/app/views/users/edit_current_user.html.erb
@@ -5,7 +5,7 @@
     <%= form_for current_user do |f| %>
 
       <div class="form-group">
-        <%= f.label :username %>
+        <%= f.label :username, 'Display Name' %>
         <%= f.text_field :username, class: 'form-control input-lg', style: 'max-width: 15em' %>
       </div>
 
@@ -18,7 +18,7 @@
         <%= f.label :dismissed_welcome_message %>
         <%= f.check_box :dismissed_welcome_message %>
       </div>
-      
+
       <div class="form-group">
         <%= f.label :digest_subscriber %>
         <%= f.check_box :digest_subscriber %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,48 @@
+<header>
+  <h1><%= t '.title' %></h1>
+</header>
+
+<div class="row">
+  <div class="col-md-6 col-sm-8 col-xs-8">
+    <% if @user.errors.any? %>
+      <div id="error_explanation">
+        <h2><%= pluralize(@user.errors.count, "error") %> prohibited this account from being created:</h2>
+        <ul>
+        <% @user.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <%= form_for @user do |form| %>
+      <fieldset>
+        <div class="form-group">
+          <%= form.label :username, 'Full Name' %>
+          <%= form.text_field :username, class: 'form-control' %>
+        </div>
+
+        <div class="form-group">
+          <%= form.label :email %>
+          <%= form.email_field :email, class: 'form-control' %>
+        </div>
+
+        <div class="form-group">
+          <%= form.label :password %>
+          <%= form.password_field :password, class: 'form-control' %>
+        </div>
+      </fieldset>
+
+      <div class="form-actions">
+        <%= form.submit class: 'btn btn-primary' %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="col-md-6 col-sm-6 col-xs-6">
+    <div style="text-align: center">
+      <h3>Or...</h3>
+      <p><%= link_to '<i class="fa fa-lg fa-github"></i> Sign up with your GitHub account'.html_safe, '/auth/github', class: 'btn btn-default btn-lg' %></p>
+    </div>
+  </div>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,6 +15,7 @@ Rubygamedev::Application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.default_url_options = { host: 'rubygamedev.dev' }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -27,5 +28,5 @@ Rubygamedev::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  Rails.application.routes.default_url_options[:host] = 'localhost:3000'
+  Rails.application.routes.default_url_options[:host] = 'rubygamedev.dev'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Rubygamedev::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Set to :debug to see everything in the log.
   config.log_level = :info

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,9 +30,10 @@ Rubygamedev::Application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = { host: 'rubygamedev.dev' }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
-  Rails.application.routes.default_url_options[:host] = 'www.rubygamedev.com'
+  Rails.application.routes.default_url_options[:host] = 'rubygamedev.dev'
 end

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -1,0 +1,3 @@
+Clearance.configure do |config|
+  config.mailer_sender = "reply@example.com"
+end

--- a/config/locales/clearance.en.yml
+++ b/config/locales/clearance.en.yml
@@ -1,0 +1,53 @@
+---
+en:
+  clearance_mailer:
+    change_password:
+      closing: If you didn't request this, ignore this email. Your password
+        has not been changed.
+      opening: 'Someone, hopefully you, requested we send you a link to change
+        your password:'
+  flashes:
+    failure_after_create: Bad email or password.
+    failure_after_update: Password can't be blank.
+    failure_when_forbidden: Please double check the URL or try submitting
+      the form again.
+  helpers:
+    label:
+      password:
+        email: Email address
+      password_reset:
+        password: Choose password
+    submit:
+      password:
+        submit: Reset password
+      password_reset:
+        submit: Save this password
+      session:
+        submit: Sign in
+      user:
+        create: Create Account
+  layouts:
+    application:
+      sign_in: Sign in
+      sign_out: Sign out
+  passwords:
+    create:
+      description: You will receive an email within the next few minutes. It
+        contains instructions for changing your password.
+    edit:
+      description: Your password has been reset. Choose a new password below.
+      title: Change your password
+    new:
+      description: To be emailed a link to reset your password, please enter
+        your email address.
+      title: Reset your password
+  sessions:
+    form:
+      forgot_password: Forgot password?
+      sign_up: Create Account
+    new:
+      title: Sign in
+  users:
+    new:
+      sign_in: Sign in
+      title: Create Account

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,9 @@
 Rubygamedev::Application.routes.draw do
 
-  get '/auth/sign_in', to: 'sessions#new', as: :sign_in
-  get '/auth/:provider/callback', to: 'sessions#create'
-  get '/auth/sign_out', to: 'sessions#destroy'
+  get '/auth/:provider/callback', to: 'sessions#create_from_omniauth'
 
-  resources :users, only: [:index, :edit, :update] # REVIEW: can we remove index?
+  resources :users, only: [:create, :edit, :update]
+  get '/account' => 'users#edit_current_user', as: :account
 
   resources :posts
 

--- a/db/migrate/20150103204002_add_clearance_to_users.rb
+++ b/db/migrate/20150103204002_add_clearance_to_users.rb
@@ -1,0 +1,28 @@
+class AddClearanceToUsers < ActiveRecord::Migration
+  def self.up
+    change_table :users  do |t|
+      t.string :encrypted_password, limit: 128
+      t.string :confirmation_token, limit: 128
+      t.string :remember_token, limit: 128
+    end
+
+    add_index :users, :email
+    add_index :users, :remember_token
+
+    users = select_all("SELECT id FROM users WHERE remember_token IS NULL")
+
+    users.each do |user|
+      update <<-SQL
+        UPDATE users
+        SET remember_token = '#{Clearance::Token.new}'
+        WHERE id = '#{user['id']}'
+      SQL
+    end
+  end
+
+  def self.down
+    change_table :users do |t|
+      t.remove :encrypted_password,:confirmation_token,:remember_token
+    end
+  end
+end

--- a/db/migrate/20150104061204_create_authentications.rb
+++ b/db/migrate/20150104061204_create_authentications.rb
@@ -1,0 +1,17 @@
+class CreateAuthentications < ActiveRecord::Migration
+  def change
+    create_table :authentications do |t|
+      t.belongs_to :user, index: true
+      t.string :provider, index: true
+      t.string :uid, index: true
+      t.string :token
+
+      t.timestamps
+    end
+
+    users = select_all("SELECT id, github_id FROM users")
+    users.each do |user|
+      Authentication.create!(user_id: user['id'], provider: 'github', uid: user['github_id'])
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140926072951) do
+ActiveRecord::Schema.define(version: 20150104061204) do
+
+  create_table "authentications", force: true do |t|
+    t.integer  "user_id"
+    t.string   "provider"
+    t.string   "uid"
+    t.string   "token"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "authentications", ["user_id"], name: "index_authentications_on_user_id"
 
   create_table "blog_posts", force: true do |t|
     t.string   "title"
@@ -124,6 +135,12 @@ ActiveRecord::Schema.define(version: 20140926072951) do
     t.boolean  "dismissed_welcome_message"
     t.string   "email"
     t.string   "github_id"
+    t.string   "encrypted_password",        limit: 128
+    t.string   "confirmation_token",        limit: 128
+    t.string   "remember_token",            limit: 128
   end
+
+  add_index "users", ["email"], name: "index_users_on_email"
+  add_index "users", ["remember_token"], name: "index_users_on_remember_token"
 
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,8 +1,7 @@
 FactoryGirl.define do
-  # user's are usually created by authenticating with GitHub which calls User.create_from_auth_hash(auth)
   factory :user do
-    github_id 123
-    username 'exampleusername'
-    email 'exampleuser@example.com'
+    username 'Mister Example' # display name
+    sequence(:email) { |n| "user#{n}@example.com" }
+    password 'password'
   end
 end


### PR DESCRIPTION
Some people have been asking for the ability to create a traditional email/password account. I think this is a good idea since not everyone has a GitHub account (especially beginners).

This pull request adds the ability to create an account and sign in using an email/password.

I have also added SSL, so I've adjusted the configs to enforce SSL throughout the site.

Please report any bugs I might have missed.