### PR TITLE
Define RSpec as our default test framework.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,5 +19,9 @@ module Rubygamedev
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    
+    config.generators do |g|
+      g.test_framework :rspec, fixture: false
+    end
   end
 end


### PR DESCRIPTION
@BubetoManolova I have now specified RSpec as the default test framework, so this will prevent us from accidentally creating TestUnit tests when using the Rails generators.